### PR TITLE
Add front matter to empty READMEs

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,7 @@
+---
+title: "GitHub Resources"
+description: "Information about repository configuration."
+tags: [github]
+---
+
+Content coming soon.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,7 @@
+---
+title: "GitHub Workflows"
+description: "CI and other automation scripts."
+tags: [workflow]
+---
+
+Content coming soon.

--- a/ai-handbook/README.md
+++ b/ai-handbook/README.md
@@ -1,0 +1,7 @@
+---
+title: "AI Handbook"
+description: "Guidelines and references for using AI."
+tags: [ai]
+---
+
+Content coming soon.

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,7 @@
+---
+title: "Assets"
+description: "Supporting images and other files."
+tags: [assets]
+---
+
+Content coming soon.

--- a/change-communication/README.md
+++ b/change-communication/README.md
@@ -1,0 +1,7 @@
+---
+title: "Change Communication"
+description: "Materials for announcing and managing change."
+tags: [change]
+---
+
+Content coming soon.

--- a/marcom-playbook/README.md
+++ b/marcom-playbook/README.md
@@ -1,0 +1,7 @@
+---
+title: "Marcom Playbook"
+description: "Marketing communications guidelines."
+tags: [marcom]
+---
+
+Content coming soon.

--- a/technical-communication-docs/README.md
+++ b/technical-communication-docs/README.md
@@ -1,0 +1,7 @@
+---
+title: "Technical Communication Docs"
+description: "Documentation for technical communication."
+tags: [technical]
+---
+
+Content coming soon.

--- a/templates-workshop/README.md
+++ b/templates-workshop/README.md
@@ -1,0 +1,7 @@
+---
+title: "Templates Workshop"
+description: "Example templates for various documents."
+tags: [templates]
+---
+
+Content coming soon.


### PR DESCRIPTION
## Summary
- add basic front matter to previously empty README files
- note that content is coming soon

## Testing
- `bash -c 'exit_code=0; for file in $(git ls-files "*.md"); do if [ ! -s "$file" ]; then echo "Skipping empty file $file" >&2; continue; fi; if ! cat "$file" | yaml-front-matter | jq -e "has("title") and has("description") and has("tags")" >/dev/null; then echo "Missing required front matter fields in $file" >&2; exit_code=1; fi; done; exit $exit_code'`

------
https://chatgpt.com/codex/tasks/task_e_68668790690083228ab0b81ac5f2f53f