### PR TITLE
Fix missing jq in frontmatter lint

### DIFF
--- a/.github/workflows/ci-frontmatter-lint.yml
+++ b/.github/workflows/ci-frontmatter-lint.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
       - name: Validate Frontmatter
         run: |
           npm install -g yaml-front-matter


### PR DESCRIPTION
## Summary
- install jq in frontmatter lint workflow to guarantee validation works

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866879a1e688322bb73544c7c8a1951