### PR TITLE
docs: normalize lists to dashes & remove redundant TOC link in ai-handbook directory

### DIFF
--- a/ai-handbook/README.md
+++ b/ai-handbook/README.md
@@ -9,7 +9,6 @@ last\_updated: 2025-07-03
 
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [About This Handbook](#about-this-handbook)
   - [What This Handbook Is Not](#what-this-handbook-is-not)
 - [Prerequisites](#prerequisites)
@@ -23,42 +22,42 @@ last\_updated: 2025-07-03
 
 This is a thinking companion built for people using generative AI—LLMs like ChatGPT, Claude, and Gemini—in personal and professional contexts. It helps you:
 
-* Examine why AI-generated answers feel right or wrong
-* Reflect on your learning rather than just your speed
-* Build mental models that go beyond simple prompts
+- Examine why AI-generated answers feel right or wrong
+- Reflect on your learning rather than just your speed
+- Build mental models that go beyond simple prompts
 
 ### What This Handbook Is Not
 
-* A technical tutorial
-* A list of productivity hacks
-* Legal, medical, financial, or compliance advice
+- A technical tutorial
+- A list of productivity hacks
+- Legal, medical, financial, or compliance advice
 
 ---
 
 ## Prerequisites
 
-* Familiarity with basic generative AI concepts (Large Language Models)
-* Willingness to pause and reflect, not just follow templates
+- Familiarity with basic generative AI concepts (Large Language Models)
+- Willingness to pause and reflect, not just follow templates
 
 ---
 
 ## What You’ll Learn
 
-* How to craft prompts that promote clarity and insight
-* Techniques for evaluating AI outputs qualitatively and quantitatively
-* Ethical frameworks for responsible AI use
-* Advanced strategies such as chain-of-thought prompting and fine-tuning concepts
+- How to craft prompts that promote clarity and insight
+- Techniques for evaluating AI outputs qualitatively and quantitatively
+- Ethical frameworks for responsible AI use
+- Advanced strategies such as chain-of-thought prompting and fine-tuning concepts
 
 ---
 
 ## Navigation
 
-* **Foundations**: [Overview](modules/01-foundations/01-overview.md)
-* **Prompt Engineering**: [Why Prompts Fail](modules/02-prompt-engineering/02-why-prompts-fail.md)
-* **Model Theory**: [How AI Thinks](modules/03-model-theory/02-how-ai-thinks.md)
-* **Model Selection**: [Choosing the Right Model](modules/04-model-selection/02-choosing-right-model.md)
-* **Model Application**: [Evaluation Metrics](modules/05-model-application/02-evaluation-metrics.md)
-* **Ethics & Governance**: [Risks and Responsibility](modules/06-ethics-governance/02-risks-and-responsibility.md)
+- **Foundations**: [Overview](modules/01-foundations/01-overview.md)
+- **Prompt Engineering**: [Why Prompts Fail](modules/02-prompt-engineering/02-why-prompts-fail.md)
+- **Model Theory**: [How AI Thinks](modules/03-model-theory/02-how-ai-thinks.md)
+- **Model Selection**: [Choosing the Right Model](modules/04-model-selection/02-choosing-right-model.md)
+- **Model Application**: [Evaluation Metrics](modules/05-model-application/02-evaluation-metrics.md)
+- **Ethics & Governance**: [Risks and Responsibility](modules/06-ethics-governance/02-risks-and-responsibility.md)
 
 ---
 


### PR DESCRIPTION
consistent markdown 